### PR TITLE
fix: cargo publish error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "The official Rust wrapper for the Top.gg API"
 readme = "README.md"
 repository = "https://github.com/top-gg/rust-sdk"
 license = "MIT"
-keywords = ["discord", "bots", "top.gg"]
+keywords = ["discord", "bots", "topgg", "dbl"]
 categories = ["api-bindings", "web-programming::http-client"]
 exclude = [".gitattributes", ".gitignore", "rustfmt.toml"]
 


### PR DESCRIPTION
Hey Mac!

Sorry about this pull request - there was a slight discrepancy in the `Cargo.toml` file preventing it from being published to `crates.io` (apparently the period in `top.gg` is not allowed as a keyword)

This **small** pull request fixes that, it shouldn't take that long to merge (it's just a single line being changed)

Sorry for bothering you, but thanks for constantly being highly enthusiastic and supporting about this SDK! <3