### PR TITLE
Implement `Debug` for `Client` and `InnerClient`

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -33,6 +33,7 @@ macro_rules! api {
   };
 }
 
+#[derive(Debug)]
 pub struct InnerClient {
   http: reqwest::Client,
   token: String,
@@ -125,6 +126,7 @@ impl InnerClient {
 
 /// A struct representing a [Top.gg API](https://docs.top.gg) client instance.
 #[must_use]
+#[derive(Debug)]
 pub struct Client {
   inner: SyncedClient,
 }


### PR DESCRIPTION
It's a bit surprising that `Client` and `InnerClient` hadn't implemented `Debug` already! Every public structure in Rust should implement `Debug` and as far as I can tell there is no reason for these two structures to not implement `Debug`.

This is in fact a necessary change for my project, as extra data that is passed to commands (such as `topgg::Client`) must implement `Debug` for logging purposes.