### PR TITLE
Fix `Client::has_voted()` endpoint

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -270,7 +270,7 @@ impl Client {
       .inner
       .send::<Voted>(
         Method::GET,
-        api!("/bots/votes?userId={}", user_id.as_snowflake()),
+        api!("/bots/check?userId={}", user_id.as_snowflake()),
         None,
       )
       .await


### PR DESCRIPTION
Previously the endpoint this method used was `/bots/votes`, which returns the last 1000 votes instead of returning whether or not a single specified user has voted, which is what the `/bots/check` endpoint does. This pull request resolves `Client::has_voted()` consistently returning an `InternalServerError`.