### PR TITLE
[feat,fix]: add recv() and receiver() functions on Autoposter, and fix bug on posting bot stats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topgg"
-version = "1.4.1"
+version = "1.4.2"
 edition = "2021"
 authors = ["null (https://github.com/null8626)", "Top.gg <support@top.gg> (https://top.gg)"]
 description = "The official Rust wrapper for the Top.gg API"

--- a/src/autoposter/mod.rs
+++ b/src/autoposter/mod.rs
@@ -194,7 +194,7 @@ where
   
   /// Takes the receiver responsible for [`recv`]. Subsequent calls to this function and [`recv`] after this call will panic.
   #[inline(always)]
-  pub async fn receiver(&mut self) -> mpsc::UnboundedReceiver<Result<()>> {
+  pub fn receiver(&mut self) -> mpsc::UnboundedReceiver<Result<()>> {
     self.receiver.take().expect("receiver() can only be called once.")
   }
 }

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -194,14 +194,16 @@ util::debug_struct! {
   #[derive(Clone, Serialize, Deserialize)]
   Stats {
     protected {
+      #[serde(skip_serializing_if = "Option::is_none")]
       shard_count: Option<usize>,
+      #[serde(skip_serializing_if = "Option::is_none")]
       server_count: Option<usize>,
     }
 
     private {
-      #[serde(default, deserialize_with = "util::deserialize_default")]
+      #[serde(default, skip_serializing_if = "Option::is_none", deserialize_with = "util::deserialize_default")]
       shards: Option<Vec<usize>>,
-      #[serde(default, deserialize_with = "util::deserialize_default")]
+      #[serde(default, skip_serializing_if = "Option::is_none", deserialize_with = "util::deserialize_default")]
       shard_id: Option<usize>,
     }
 


### PR DESCRIPTION
Fixes #23
Fixes #24

The following pull request:
- Adds an `Autoposter::recv()` async function that resolves every time the autoposter has posted the data (or not due to an error)
- Adds an `Autoposter::receiver()` function that returns the `mpsc::UnboundedReceiver` object directly for further processing
- Fixes a bug where posting bot stats never works